### PR TITLE
Validation fixes for numerical operations

### DIFF
--- a/src/math.ts
+++ b/src/math.ts
@@ -46,6 +46,9 @@ export function degToRad(degrees: number): number {
 }
 
 export function approxEquals(a: number, b: number, epsilon = 1e-6): boolean {
+  if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(epsilon) || epsilon < 0) {
+    return false
+  }
   return Math.abs(a - b) < epsilon
 }
 

--- a/src/math.ts
+++ b/src/math.ts
@@ -30,7 +30,12 @@ export function roundTo(n: number, decimals = 0): number {
 }
 
 export function randFloat(min: number, max: number): number {
-  return Math.random() * (max - min) + min
+  const [minVal, maxVal] = [Math.min(min, max), Math.max(min, max)]
+  if (!Number.isFinite(minVal) || !Number.isFinite(maxVal)) {
+    return Number.NaN
+  }
+
+  return Math.random() * (maxVal - minVal) + minVal
 }
 
 export function degToRad(degrees: number): number {
@@ -46,8 +51,8 @@ export function approxEquals(a: number, b: number, epsilon = 1e-6): boolean {
 
 export function fract(n: number): number {
   if (!Number.isFinite(n)) {
-    return Number.NaN;
+    return Number.NaN
   }
-  
+
   return n - Math.trunc(n)
 }

--- a/src/math.ts
+++ b/src/math.ts
@@ -9,6 +9,11 @@ export function lerp(min: number, max: number, t: number): number {
 }
 
 export function remap(n: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
+  if (!Number.isFinite(n) || !Number.isFinite(inMin) || !Number.isFinite(inMax)
+    || +!Number.isFinite(outMin) || !Number.isFinite(outMax)) {
+    return Number.NaN
+  }
+
   if (inMin === inMax) {
     return (outMin + outMax) / 2
   }

--- a/src/math.ts
+++ b/src/math.ts
@@ -17,6 +17,9 @@ export function remap(n: number, inMin: number, inMax: number, outMin: number, o
 }
 
 export function roundTo(n: number, decimals = 0): number {
+  if (decimals < 0) {
+    throw new Error('decimals must be a non-negative integer')
+  }
   const factor = 10 ** decimals
   return Math.round((n + Number.EPSILON) * factor) / factor
 }

--- a/src/math.ts
+++ b/src/math.ts
@@ -45,5 +45,9 @@ export function approxEquals(a: number, b: number, epsilon = 1e-6): boolean {
 }
 
 export function fract(n: number): number {
+  if (!Number.isFinite(n)) {
+    return Number.NaN;
+  }
+  
   return n - Math.trunc(n)
 }

--- a/src/math.ts
+++ b/src/math.ts
@@ -22,7 +22,7 @@ export function remap(n: number, inMin: number, inMax: number, outMin: number, o
 }
 
 export function roundTo(n: number, decimals = 0): number {
-  if (decimals < 0) {
+  if (decimals < 0 || Number.isInteger(decimals)) {
     throw new Error('decimals must be a non-negative integer')
   }
   const factor = 10 ** decimals

--- a/src/math.ts
+++ b/src/math.ts
@@ -26,6 +26,9 @@ export function randFloat(min: number, max: number): number {
 }
 
 export function degToRad(degrees: number): number {
+  if (!Number.isFinite(degrees)) {
+    return Number.NaN
+  }
   return degrees * (Math.PI / 180)
 }
 

--- a/src/math.ts
+++ b/src/math.ts
@@ -10,7 +10,7 @@ export function lerp(min: number, max: number, t: number): number {
 
 export function remap(n: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
   if (!Number.isFinite(n) || !Number.isFinite(inMin) || !Number.isFinite(inMax)
-    || +!Number.isFinite(outMin) || !Number.isFinite(outMax)) {
+    || !Number.isFinite(outMin) || !Number.isFinite(outMax)) {
     return Number.NaN
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR introduces several checks to make sure the validation is correct across the board and utilities are working as expected. Specifically:

*   `remap`: Returns `NaN` if any input is not a finite number.
*   `roundTo`: Throws an error if `decimals` is negative.
*   `randFloat`: Returns `NaN` if either `min` or `max` is not a finite number.
*   `degToRad`: Returns `NaN` if `degrees` is not a finite number.
*   `approxEquals`: Returns `false` if `a`, `b`, or `epsilon` is not a finite number, or if `epsilon` is negative.
*   `fract`: Returns `NaN` if `n` is not a finite number.

